### PR TITLE
fix: reverse replace order

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ _escape= function(s) {
     return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 };
 
-let xsRE  = new RegExp('('+Object.keys(_xsampa).filter(x => !!x).map(_escape).join('|')+')', 'g');
-let ipaRE = new RegExp('('+Object.keys(_ipa).filter(x => !!x).map(_escape).join('|')+')', 'g');
+let xsRE  = new RegExp('('+Object.keys(_xsampa).reverse().filter(x => !!x).map(_escape).join('|')+')', 'g');
+let ipaRE = new RegExp('('+Object.keys(_ipa).reverse().filter(x => !!x).map(_escape).join('|')+')', 'g');
 
 
 


### PR DESCRIPTION
The replacing order was not fully correct.

Example:
    IPA: _ˈaːbn̩dən_
will be
    XSAMPA: _"a:bn_=d@n_
What ist correct.

But if you try the other way round:
    XSAMPA: _"a:bn_=d@n_
the result will be
    IPA: _ˈaːbn̈=dən_
    
Reversing the replacement (or json structure) fixes the issue.